### PR TITLE
Support Avro INT for all XML int-like primitive types

### DIFF
--- a/src/ly/stealth/xmlavro/SchemaBuilder.java
+++ b/src/ly/stealth/xmlavro/SchemaBuilder.java
@@ -23,6 +23,28 @@ public class SchemaBuilder {
     private boolean debug;
     private Resolver resolver;
 
+    private static Map<Short, Schema.Type> xmlToAvroTypes = new HashMap<>();
+
+    private static void setAvroForXml(Schema.Type avroType, short... xmlTypes) {
+      for (short xmlType : xmlTypes) {
+        xmlToAvroTypes.put(xmlType, avroType);
+      }
+    }
+
+    private static Schema.Type getAvroFor(short xmlType) {
+      Schema.Type avroType = xmlToAvroTypes.get(xmlType);
+      return avroType == null ? Schema.Type.STRING : avroType;
+    }
+
+    static {
+      setAvroForXml(Schema.Type.BOOLEAN, XSConstants.BOOLEAN_DT);
+      setAvroForXml(Schema.Type.INT, XSConstants.INT_DT, XSConstants.BYTE_DT, XSConstants.SHORT_DT,
+              XSConstants.UNSIGNEDBYTE_DT, XSConstants.UNSIGNEDSHORT_DT);
+      setAvroForXml(Schema.Type.LONG, XSConstants.LONG_DT, XSConstants.UNSIGNEDINT_DT);
+      setAvroForXml(Schema.Type.FLOAT, XSConstants.FLOAT_DT);
+      setAvroForXml(Schema.Type.DOUBLE, XSConstants.DOUBLE_DT, XSConstants.DECIMAL_DT);
+    }
+
     private Map<String, Schema> schemas = new LinkedHashMap<>();
 
     public boolean getDebug() { return debug; }
@@ -245,14 +267,7 @@ public class SchemaBuilder {
     }
 
     private Schema.Type getPrimitiveType(XSSimpleTypeDefinition type) {
-        switch (type.getBuiltInKind()) {
-            case XSConstants.BOOLEAN_DT: return Schema.Type.BOOLEAN;
-            case XSConstants.INT_DT: return Schema.Type.INT;
-            case XSConstants.LONG_DT: return Schema.Type.LONG;
-            case XSConstants.FLOAT_DT: return Schema.Type.FLOAT;
-            case XSConstants.DOUBLE_DT: return Schema.Type.DOUBLE;
-            default: return Schema.Type.STRING;
-        }
+      return getAvroFor(type.getBuiltInKind());
     }
 
     static String uniqueFieldName(Iterable<Schema.Field> fields, String name) {

--- a/test/ly/stealth/xmlavro/ConverterTest.java
+++ b/test/ly/stealth/xmlavro/ConverterTest.java
@@ -45,17 +45,44 @@ public class ConverterTest {
     }
 
     @Test
-    public void rootPrimitive() {
+    public void rootIntPrimitive() {
+        rootPrimitiveWithType("xs:int", "-1", Schema.Type.INT, -1);
+        rootPrimitiveWithType("xs:integer", "-5", Schema.Type.INT, -5);
+        rootPrimitiveWithType("xs:unsignedByte", "1", Schema.Type.INT, 1);
+        rootPrimitiveWithType("xs:unsignedShort", "5", Schema.Type.INT, 5);
+        rootPrimitiveWithType("xs:negativeInteger", "-10", Schema.Type.INT, -10);
+        rootPrimitiveWithType("xs:nonPositiveInteger", "0", Schema.Type.INT, 0);
+        rootPrimitiveWithType("xs:nonNegativeInteger", "0", Schema.Type.INT, 0);
+        rootPrimitiveWithType("xs:positiveInteger", "10", Schema.Type.INT, 10);
+    }
+
+    @Test
+    public void rootLongPrimitive() {
+        rootPrimitiveWithType("xs:long", "20", Schema.Type.LONG, new Long(20));
+        rootPrimitiveWithType("xs:unsignedInt", "30", Schema.Type.LONG, new Long(30));
+    }
+
+    @Test
+    public void rootDoublePrimitive() {
+        rootPrimitiveWithType("xs:decimal", "999999999.999999999", Schema.Type.DOUBLE, new Double(999999999.999999999));
+    }
+
+    @Test
+    public void rootUnsignedLongShouldBeKeptAsAvroString() {
+        rootPrimitiveWithType("xs:unsignedLong", "18446744073709551615", Schema.Type.STRING, "18446744073709551615");
+    }
+
+    public <T> void rootPrimitiveWithType(String xsdType, String xmlValue, Schema.Type avroType, T avroValue) {
         String xsd =
                 "<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'>" +
-                "   <xs:element name='i' type='xs:int'/>" +
+                "   <xs:element name='value' type='" + xsdType + "'/>" +
                 "</xs:schema>";
 
         Schema schema = Converter.createSchema(xsd);
-        assertEquals(Schema.Type.INT, schema.getType());
+        assertEquals(avroType, schema.getType());
 
-        String xml = "<i>1</i>";
-        assertEquals(1, Converter.createDatum(schema, xml));
+        String xml = "<value>" + xmlValue + "</value>";
+        assertEquals(avroValue, Converter.createDatum(schema, xml));
     }
 
     @Test


### PR DESCRIPTION
Many XML types could be better represented as Avro INT
instead of a String.
