### PR TITLE
Enable tests execution during build and fix Integer conversion test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
 
     <build>
         <sourceDirectory>src</sourceDirectory>
+        <testSourceDirectory>test</testSourceDirectory>
         <resources>
             <resource>
                 <directory>src</directory>

--- a/src/ly/stealth/xmlavro/SchemaBuilder.java
+++ b/src/ly/stealth/xmlavro/SchemaBuilder.java
@@ -28,15 +28,16 @@ public class SchemaBuilder {
         primitives.put(XSConstants.BOOLEAN_DT, Schema.Type.BOOLEAN);
 
         primitives.put(XSConstants.INT_DT, Schema.Type.INT);
-        primitives.put(XSConstants.INTEGER_DT, Schema.Type.INT);
-        primitives.put(XSConstants.NEGATIVEINTEGER_DT, Schema.Type.INT);
-        primitives.put(XSConstants.NONNEGATIVEINTEGER_DT, Schema.Type.INT);
-        primitives.put(XSConstants.POSITIVEINTEGER_DT, Schema.Type.INT);
-        primitives.put(XSConstants.NONPOSITIVEINTEGER_DT, Schema.Type.INT);
         primitives.put(XSConstants.BYTE_DT, Schema.Type.INT);
         primitives.put(XSConstants.SHORT_DT, Schema.Type.INT);
         primitives.put(XSConstants.UNSIGNEDBYTE_DT, Schema.Type.INT);
         primitives.put(XSConstants.UNSIGNEDSHORT_DT, Schema.Type.INT);
+
+        primitives.put(XSConstants.INTEGER_DT, Schema.Type.STRING);
+        primitives.put(XSConstants.NEGATIVEINTEGER_DT, Schema.Type.STRING);
+        primitives.put(XSConstants.NONNEGATIVEINTEGER_DT, Schema.Type.STRING);
+        primitives.put(XSConstants.POSITIVEINTEGER_DT, Schema.Type.STRING);
+        primitives.put(XSConstants.NONPOSITIVEINTEGER_DT, Schema.Type.STRING);
 
         primitives.put(XSConstants.LONG_DT, Schema.Type.LONG);
         primitives.put(XSConstants.UNSIGNEDINT_DT, Schema.Type.LONG);

--- a/test/ly/stealth/xmlavro/ConverterTest.java
+++ b/test/ly/stealth/xmlavro/ConverterTest.java
@@ -47,13 +47,8 @@ public class ConverterTest {
     @Test
     public void rootIntPrimitive() {
         rootPrimitiveWithType("xs:int", "-1", Schema.Type.INT, -1);
-        rootPrimitiveWithType("xs:integer", "-5", Schema.Type.INT, -5);
         rootPrimitiveWithType("xs:unsignedByte", "1", Schema.Type.INT, 1);
         rootPrimitiveWithType("xs:unsignedShort", "5", Schema.Type.INT, 5);
-        rootPrimitiveWithType("xs:negativeInteger", "-10", Schema.Type.INT, -10);
-        rootPrimitiveWithType("xs:nonPositiveInteger", "0", Schema.Type.INT, 0);
-        rootPrimitiveWithType("xs:nonNegativeInteger", "0", Schema.Type.INT, 0);
-        rootPrimitiveWithType("xs:positiveInteger", "10", Schema.Type.INT, 10);
     }
 
     @Test


### PR DESCRIPTION
Tests were not executed before during build because of a missing
configuration parameter for the sureFire plugin (testSourceDirectory).

Now that tests are enabled, the Integer data type to Avro Int needs
to be disabled as we agreed during the GitHub Pull Request discussion
to consider the unbound XML Integer as String (Avro Int is 32-bit signed
and thus could overflow)
