### PR TITLE
Use Avro Long epoch for representing XML dateTime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,11 @@
             <version>1.7.5</version>
         </dependency>
         <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>2.5</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.8.1</version>

--- a/src/ly/stealth/xmlavro/DatumBuilder.java
+++ b/src/ly/stealth/xmlavro/DatumBuilder.java
@@ -2,6 +2,7 @@ package ly.stealth.xmlavro;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
+import org.joda.time.DateTimeZone;
 import org.w3c.dom.*;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -42,6 +43,12 @@ public class DatumBuilder {
 
     private Schema schema;
     private boolean caseSensitiveNames = true;
+
+    private static XmlDateTimeFormatter xmlDateTimeFormatter = new XmlDateTimeFormatter();
+
+    public static void setDefaultTimeZone(DateTimeZone defTimeZone) {
+      xmlDateTimeFormatter = new XmlDateTimeFormatter(defTimeZone);
+    }
 
     public DatumBuilder(Schema schema) {
         this.schema = schema;
@@ -116,8 +123,13 @@ public class DatumBuilder {
         if (type == Schema.Type.INT)
             return Integer.parseInt(text);
 
-        if (type == Schema.Type.LONG)
-            return Long.parseLong(text);
+        if (type == Schema.Type.LONG) {
+           if (xmlDateTimeFormatter.isDateTimeXmlValue(text)) {
+             return xmlDateTimeFormatter.parseMillis(text);
+           } else {
+             return Long.parseLong(text);
+           }
+        }
 
         if (type == Schema.Type.FLOAT)
             return Float.parseFloat(text);

--- a/src/ly/stealth/xmlavro/SchemaBuilder.java
+++ b/src/ly/stealth/xmlavro/SchemaBuilder.java
@@ -45,6 +45,8 @@ public class SchemaBuilder {
 
         primitives.put(XSConstants.DOUBLE_DT, Schema.Type.DOUBLE);
         primitives.put(XSConstants.DECIMAL_DT, Schema.Type.DOUBLE);
+
+        primitives.put(XSConstants.DATETIME_DT, Schema.Type.LONG);
     }
 
     private Map<String, Schema> schemas = new LinkedHashMap<>();

--- a/src/ly/stealth/xmlavro/XmlDateTimeFormatter.java
+++ b/src/ly/stealth/xmlavro/XmlDateTimeFormatter.java
@@ -1,0 +1,56 @@
+package ly.stealth.xmlavro;
+
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
+import java.util.regex.Pattern;
+
+class XmlDateTimeFormatter {
+  private final DateTimeFormatter dateTimeFormatter;
+  private final DateTimeFormatter dateTimeFormatterTz;
+  private final DateTimeFormatter dateTimeFormatterWithDecimals;
+  private final DateTimeFormatter dateTimeFormatterWithDecimalsTz;
+  private final Pattern timeZonePattern = Pattern.compile(".*[+-][0-9][0-9]:[0-9][0-9]");
+
+  XmlDateTimeFormatter() {
+    this(DateTimeZone.UTC);
+  }
+
+  XmlDateTimeFormatter(DateTimeZone zone) {
+    dateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss").withZone(zone);
+    dateTimeFormatterTz = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ssZ");
+    dateTimeFormatterWithDecimals = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.S").withZone(zone);
+    dateTimeFormatterWithDecimalsTz = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SZ");
+  }
+
+  boolean isDateTimeXmlValue(String dateText) {
+    return dateText.indexOf('T') > 0;
+  }
+
+  DateTimeFormatter getDateTimeFormat(String dateText) {
+    if (hasDecimal(dateText)) {
+      return endsWithTimeZone(dateText) ? dateTimeFormatterWithDecimalsTz : dateTimeFormatterWithDecimals;
+    } else {
+      return endsWithTimeZone(dateText) ? dateTimeFormatterTz : dateTimeFormatter;
+    }
+  }
+
+  private boolean hasDecimal(String dateText) {
+    return dateText.indexOf('.') > 0;
+  }
+
+  private boolean endsWithTimeZone(String dateText) {
+    boolean matches = timeZonePattern.matcher(dateText).matches();
+    return matches;
+  }
+
+  long parseMillis(String text) {
+    DateTimeFormatter formatter = getDateTimeFormat(text);
+    if (text.endsWith("Z")) {
+      return formatter.withZoneUTC().parseMillis(text.substring(0, text.length() - 1));
+    } else {
+      return formatter.parseMillis(text);
+    }
+  }
+}

--- a/test/ly/stealth/xmlavro/ConverterTest.java
+++ b/test/ly/stealth/xmlavro/ConverterTest.java
@@ -18,6 +18,7 @@ package ly.stealth.xmlavro;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
+import org.joda.time.DateTimeZone;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -70,6 +71,17 @@ public class ConverterTest {
     @Test
     public void rootUnsignedLongShouldBeKeptAsAvroString() {
         rootPrimitiveWithType("xs:unsignedLong", "18446744073709551615", Schema.Type.STRING, "18446744073709551615");
+    }
+
+
+    @Test
+    public void rootDateTimePrimitive() {
+      rootPrimitiveWithType("xs:dateTime", "2014-10-30T14:58:33", Schema.Type.LONG, new Long(1414681113000L));
+      rootPrimitiveWithType("xs:dateTime", "2014-09-10T12:58:33", Schema.Type.LONG, new Long(1410353913000L));
+
+      DatumBuilder.setDefaultTimeZone(DateTimeZone.forID("America/Los_Angeles"));
+      rootPrimitiveWithType("xs:dateTime", "2014-10-30T07:58:33", Schema.Type.LONG, new Long(1414681113000L));
+      rootPrimitiveWithType("xs:dateTime", "2014-09-10T05:58:33", Schema.Type.LONG, new Long(1410353913000L));
     }
 
     public <T> void rootPrimitiveWithType(String xmlType, String xmlValue, Schema.Type avroType, T avroValue) {

--- a/test/ly/stealth/xmlavro/XmlDateTimeFormatterTest.java
+++ b/test/ly/stealth/xmlavro/XmlDateTimeFormatterTest.java
@@ -1,0 +1,43 @@
+package ly.stealth.xmlavro;
+
+import org.joda.time.DateTimeZone;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class XmlDateTimeFormatterTest {
+
+  @Test
+  public void shouldFormatXmlBasedOnSolarTimeUsingDefaultUTCTime() {
+    String xmlDateNoTz = "2014-10-09T12:58:33";
+    long epochTs = new XmlDateTimeFormatter().parseMillis(xmlDateNoTz);
+    assertEquals(1412859513000L, epochTs);
+  }
+
+  @Test
+  public void shouldFormatXmlWithDecimalsBasedOnSolarTimeUsingDefaultUTCTime() {
+    String xmlDateWithDecimalNoTz = "2014-10-09T12:58:33.5";
+    long epochTs = new XmlDateTimeFormatter().parseMillis(xmlDateWithDecimalNoTz);
+    assertEquals(1412859513500L, epochTs);
+  }
+
+  @Test
+  public void shouldFormatXmlDateWithDaylightSavingUsingBSTTimeZone() {
+    String xmlDateNoTz = "2014-10-09T12:58:33";
+    long epochTs = new XmlDateTimeFormatter(DateTimeZone.forID("Europe/London")).parseMillis(xmlDateNoTz);
+    assertEquals(1412855913000L, epochTs);
+  }
+
+  @Test
+  public void shouldFormatXmlDateWithUtcTZWithDefaultBSTTimeZone() {
+    String xmlDateNoTz = "2014-10-09T12:58:33Z";
+    long epochTs = new XmlDateTimeFormatter(DateTimeZone.forID("Europe/London")).parseMillis(xmlDateNoTz);
+    assertEquals(1412859513000L, epochTs);
+  }
+
+  @Test
+  public void shouldFormatXmlDateWithCetTZ() {
+    String xmlDateWithCetTz = "2014-10-09T14:58:33+02:00";
+    long epochTs = new XmlDateTimeFormatter().parseMillis(xmlDateWithCetTz);
+    assertEquals(1412859513000L, epochTs);
+  }
+}


### PR DESCRIPTION
Date/Times are often present in XML data (time-stamps) and are 
often taking a lot of CPU for parsing and bytes for storing them
as strings.

Using an Avro Long type for their corresponding Unix Epoch mills
would allow to have a faster processing and more compact storage.
