### PR TITLE
Encode optional value as Avro Union with “null” as first element

### DIFF
--- a/src/ly/stealth/xmlavro/DatumBuilder.java
+++ b/src/ly/stealth/xmlavro/DatumBuilder.java
@@ -119,10 +119,10 @@ public class DatumBuilder {
   private Object createUnionDatum(Schema union, Node source) {
         List<Schema> types = union.getTypes();
 
-        boolean optionalNode = types.size() == 2 && types.get(1).getType() == Schema.Type.NULL;
+        boolean optionalNode = types.size() == 2 && types.get(0).getType() == Schema.Type.NULL;
         if (!optionalNode) throw new ConverterException("Unsupported union types " + types);
 
-        return createNodeDatum(types.get(0), source, false);
+        return createNodeDatum(types.get(1), source, false);
     }
 
     private Object createValue(Schema.Type type, String text) {

--- a/src/ly/stealth/xmlavro/SchemaBuilder.java
+++ b/src/ly/stealth/xmlavro/SchemaBuilder.java
@@ -123,7 +123,7 @@ public class SchemaBuilder {
         for (Source source : schemas.keySet()) {
             Schema schema = schemas.get(source);
             Schema nullSchema = Schema.create(Schema.Type.NULL);
-            Schema optionalSchema = Schema.createUnion(Arrays.asList(schema, nullSchema));
+            Schema optionalSchema = Schema.createUnion(Arrays.asList(nullSchema, schema));
 
             Schema.Field field = new Schema.Field(source.getName(), optionalSchema, null, null);
             field.addProp(Source.SOURCE, "" + source);
@@ -154,7 +154,7 @@ public class SchemaBuilder {
             schema = Schema.createArray(schema);
         else if (optional) {
             Schema nullSchema = Schema.create(Schema.Type.NULL);
-            schema = Schema.createUnion(Arrays.asList(schema, nullSchema));
+            schema = Schema.createUnion(Arrays.asList(nullSchema, schema));
         }
 
         typeLevel--;

--- a/test/ly/stealth/xmlavro/ConverterTest.java
+++ b/test/ly/stealth/xmlavro/ConverterTest.java
@@ -107,14 +107,14 @@ public class ConverterTest {
         Schema.Field field0 = schema.getFields().get(0);
         assertEquals("" + new Source("i"), field0.getProp(Source.SOURCE));
         assertEquals(Schema.Type.UNION, field0.schema().getType());
-        assertEquals(Schema.Type.INT, field0.schema().getTypes().get(0).getType());
-        assertEquals(Schema.Type.NULL, field0.schema().getTypes().get(1).getType());
+        assertEquals(Schema.Type.INT, field0.schema().getTypes().get(1).getType());
+        assertEquals(Schema.Type.NULL, field0.schema().getTypes().get(0).getType());
 
         Schema.Field field1 = schema.getFields().get(1);
         assertEquals("" + new Source("r"), field1.getProp(Source.SOURCE));
         assertEquals(Schema.Type.UNION, field1.schema().getType());
-        assertEquals(Schema.Type.RECORD, field1.schema().getTypes().get(0).getType());
-        assertEquals(Schema.Type.NULL, field1.schema().getTypes().get(1).getType());
+        assertEquals(Schema.Type.RECORD, field1.schema().getTypes().get(1).getType());
+        assertEquals(Schema.Type.NULL, field1.schema().getTypes().get(0).getType());
 
         String xml = "<i>5</i>";
         GenericData.Record record = Converter.createDatum(schema, xml);
@@ -181,7 +181,7 @@ public class ConverterTest {
 
         Schema.Field field = schema.getField("node");
         Schema subSchema = field.schema();
-        assertSame(schema, subSchema.getTypes().get(0));
+        assertSame(schema, subSchema.getTypes().get(1));
 
         String xml = "<root><node></node></root>";
         GenericData.Record record = Converter.createDatum(schema, xml);
@@ -215,7 +215,7 @@ public class ConverterTest {
         Schema.Field optional = schema.getField("optional");
         assertEquals(Schema.Type.UNION, optional.schema().getType());
         assertEquals(
-                Arrays.asList(Schema.create(Schema.Type.STRING), Schema.create(Schema.Type.NULL)),
+                Arrays.asList(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING)),
                 optional.schema().getTypes()
         );
 
@@ -351,7 +351,7 @@ public class ConverterTest {
         assertEquals(Schema.Type.UNION, optionalSchema.getType());
 
         assertEquals(
-                Arrays.asList(Schema.create(Schema.Type.STRING), Schema.create(Schema.Type.NULL)),
+                Arrays.asList(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING)),
                 optionalSchema.getTypes()
         );
 
@@ -419,13 +419,13 @@ public class ConverterTest {
         Schema.Field sField = schema.getField("s");
         assertEquals(Schema.Type.UNION, sField.schema().getType());
         assertEquals(
-                Arrays.asList(Schema.create(Schema.Type.STRING), Schema.create(Schema.Type.NULL)),
+                Arrays.asList(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING)),
                 sField.schema().getTypes()
         );
 
         Schema.Field iField = schema.getField("i");
         assertEquals(Schema.Type.UNION, iField.schema().getType());
-        assertEquals(Arrays.asList(Schema.create(Schema.Type.INT), Schema.create(Schema.Type.NULL)), iField.schema().getTypes());
+        assertEquals(Arrays.asList(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.INT)), iField.schema().getTypes());
 
         String xml = "<root><s>s</s></root>";
         GenericData.Record record = Converter.createDatum(schema, xml);


### PR DESCRIPTION
Optional values were correctly encoded as Avro Union type, but
unfortunately the “null” was placed on the second position, meaning
that the default value was actually required (and not optional).

The correct pattern to use Avro Union for optional values is described
in the Apache Avro documentation:

“Unions
Unions, as mentioned above, are represented using JSON arrays.
For example, ["null", "string"] declares a schema which may be either
a null or string.

(Note that when a default value is specified for a record field whose
type is a union, the type of the default value must match the first
element of the union. Thus, for unions containing "null", the "null"
is usually listed first, since the default value of such unions is
typically null.)”
