### PR TITLE
Define a generated name for self-generated root schema record

### DIFF
--- a/src/ly/stealth/xmlavro/SchemaBuilder.java
+++ b/src/ly/stealth/xmlavro/SchemaBuilder.java
@@ -130,7 +130,8 @@ public class SchemaBuilder {
             fields.add(field);
         }
 
-        Schema schema = Schema.createRecord(fields);
+        Schema schema = Schema.createRecord(nextTypeName(), "", "", false);
+        schema.setFields(fields);
         schema.addProp(Source.SOURCE, Source.DOCUMENT);
         return schema;
     }

--- a/test/ly/stealth/xmlavro/ConverterTest.java
+++ b/test/ly/stealth/xmlavro/ConverterTest.java
@@ -101,6 +101,7 @@ public class ConverterTest {
 
         Schema schema = Converter.createSchema(xsd);
         assertEquals(Schema.Type.RECORD, schema.getType());
+        assertTrue("Schema should have a valid name", schema.getName() != null && !schema.getName().isEmpty());
         assertEquals(Source.DOCUMENT, schema.getProp(Source.SOURCE));
         assertEquals(2, schema.getFields().size());
 


### PR DESCRIPTION
When an XML contains more than one element type, 
SchemaBuilder generates automatically a root record type on the
corresponding Avro schema. Generated root record type needs to be
named otherwise the Avro schema parsers would complain.

Avro schema type name is mandatory, according to specs.
