### PR TITLE
Encode group particles as separate records when maxOccurs > 1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.2.3</version>
+        </dependency>
+        <dependency>
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
             <version>2.11.0</version>

--- a/src/ly/stealth/xmlavro/DatumBuilder.java
+++ b/src/ly/stealth/xmlavro/DatumBuilder.java
@@ -84,7 +84,7 @@ public class DatumBuilder {
         return (T) createNodeDatum(schema, el, false);
     }
 
-    private Object createNodeDatum(Schema schema, Node source, boolean partOfArray) {
+    private Object createNodeDatum(Schema schema, Node source, boolean setRecordFromNode) {
         if (!Arrays.asList(Node.ELEMENT_NODE, Node.ATTRIBUTE_NODE).contains(source.getNodeType()))
             throw new IllegalArgumentException("Unsupported node type " + source.getNodeType());
 
@@ -95,7 +95,7 @@ public class DatumBuilder {
             return createUnionDatum(schema, source);
 
         if (schema.getType() == Schema.Type.RECORD)
-            return createRecord(schema, (Element) source, partOfArray);
+            return createRecord(schema, (Element) source, setRecordFromNode);
 
         if (schema.getType() == Schema.Type.ARRAY)
           return createArray(schema, (Element) source);
@@ -147,7 +147,7 @@ public class DatumBuilder {
         throw new ConverterException("Unsupported type " + type);
     }
 
-    private GenericData.Record createRecord(Schema schema, Element el, boolean partOfArray) {
+    private GenericData.Record createRecord(Schema schema, Element el, boolean setRecordFieldFromNode) {
         GenericData.Record record = new GenericData.Record(schema);
 
         // initialize arrays and wildcard maps
@@ -162,7 +162,7 @@ public class DatumBuilder {
 
         boolean rootRecord = Source.DOCUMENT.equals(schema.getProp(Source.SOURCE));
 
-        if (partOfArray) {
+        if (setRecordFieldFromNode) {
           setFieldFromNode(schema, record, el);
         } else {
           NodeList nodes = rootRecord ? el.getOwnerDocument().getChildNodes() : el.getChildNodes();
@@ -182,13 +182,14 @@ public class DatumBuilder {
                 List<String> ignoredNames = Arrays.asList("xml:lang");
                 if (ignoredNames.contains(attr.getName())) continue;
 
-                Schema.Field field = getFieldBySource(schema, new Source(attr.getName(), true));
-
-                if (field == null)
+                if(!setRecordFieldFromNode) {
+                  Schema.Field field = getFieldBySource(schema, new Source(attr.getName(), true));
+                  if (field == null)
                     throw new ConverterException("Unsupported attribute " + attr.getName());
 
-                Object datum = createNodeDatum(field.schema(), attr, false);
-                record.put(field.name(), datum);
+                  Object datum = createNodeDatum(field.schema(), attr, false);
+                  record.put(field.name(), datum);
+                }
             }
         }
 
@@ -200,11 +201,17 @@ public class DatumBuilder {
             return;
 
         Element child = (Element) node;
-        Schema.Field field = getFieldBySource(schema, new Source(child.getLocalName(), false));
+        boolean setRecordFromNode = false;
+        final String fieldName = child.getLocalName();
+        Schema.Field field = getFieldBySource(schema, new Source(fieldName, false));
+        if(field == null) {
+          field = getNestedFieldBySource(schema, new Source(fieldName, false));
+          setRecordFromNode = true;
+        }
 
         if (field != null) {
             boolean array = field.schema().getType() == Schema.Type.ARRAY;
-            Object datum = createNodeDatum(!array ? field.schema() : field.schema().getElementType(), child, false);
+          Object datum = createNodeDatum(!array ? field.schema() : field.schema().getElementType(), child, setRecordFromNode);
 
             if (!array)
                 record.put(field.name(), datum);
@@ -215,21 +222,49 @@ public class DatumBuilder {
         } else {
             Schema.Field anyField = schema.getField(Source.WILDCARD);
             if (anyField == null)
-                throw new ConverterException("Type doesn't support any element");
+                throw new ConverterException("Could not find field " + fieldName + " in Avro Schema " + schema.getName() +  " , neither as specific field nor 'any' element");
 
             @SuppressWarnings("unchecked") Map<String, String> map = (HashMap<String, String>) record.get(Source.WILDCARD);
-            map.put(child.getLocalName(), getContentAsText(child));
+            map.put(fieldName, getContentAsText(child));
         }
     }
 
     Schema.Field getFieldBySource(Schema schema, Source source) {
-        for (Schema.Field field : schema.getFields()) {
+        if(schema.getType() == Schema.Type.UNION) {
+          return getFieldBySource(schema.getTypes().get(1), source);
+        } else {
+          for (Schema.Field field : schema.getFields()) {
             String fieldSource = field.getProp(Source.SOURCE);
-            if (caseSensitiveNames && source.toString().equals(fieldSource)) return field;
-            if (!caseSensitiveNames && source.toString().equalsIgnoreCase(fieldSource)) return field;
-        }
+            if (caseSensitiveNames && source.toString().equals(fieldSource))
+              return field;
+            if (!caseSensitiveNames && source.toString().equalsIgnoreCase(fieldSource))
+              return field;
+          }
 
+          return null;
+        }
+    }
+
+    Schema.Field getNestedFieldBySource(Schema schema, Source source) {
+      if(schema.getType() != Schema.Type.RECORD) {
         return null;
+      }
+
+      for (Schema.Field field : schema.getFields()) {
+        Schema topSchema = field.schema();
+
+        switch (topSchema.getType()) {
+          case ARRAY: {
+            Schema.Field fieldBySource = getFieldBySource(topSchema.getElementType(), source);
+            if (fieldBySource != null) {
+              return field;
+            }
+          }
+          break;
+        }
+      }
+
+      return null;
     }
 
     private String getContentAsText(Element el) {

--- a/src/ly/stealth/xmlavro/SchemaBuilder.java
+++ b/src/ly/stealth/xmlavro/SchemaBuilder.java
@@ -136,6 +136,7 @@ public class SchemaBuilder {
     }
 
     private int typeLevel;
+
     private Schema createTypeSchema(XSTypeDefinition type, boolean optional, boolean array) {
         typeLevel++;
         Schema schema;
@@ -150,7 +151,7 @@ public class SchemaBuilder {
             if (schema == null) schema = createRecordSchema(name, (XSComplexTypeDefinition) type);
         }
 
-        if (array || isComplexTypeChoiceWithOccurs(type))
+        if (array || isGroupTypeWithMultipleOccurs(type))
             schema = Schema.createArray(schema);
         else if (optional) {
             Schema nullSchema = Schema.create(Schema.Type.NULL);
@@ -161,17 +162,50 @@ public class SchemaBuilder {
         return schema;
     }
 
-    private boolean isComplexTypeChoiceWithOccurs(XSTypeDefinition type) {
-      if(!(type instanceof  XSComplexTypeDefinition)) return false;
+    private boolean isGroupTypeWithMultipleOccurs(XSTypeDefinition type) {
+      return type instanceof XSComplexTypeDefinition &&
+              isGroupTypeWithMultipleOccurs(((XSComplexTypeDefinition) type).getParticle());
+    }
 
-      XSParticle particle = ((XSComplexTypeDefinition) type).getParticle();
+    private boolean isGroupTypeWithMultipleOccurs(XSParticle particle) {
       if (particle == null) return false;
 
       XSTerm term = particle.getTerm();
       if (term.getType() != XSConstants.MODEL_GROUP) return false;
 
       XSModelGroup group = (XSModelGroup) term;
-      return group.getCompositor() == XSModelGroup.COMPOSITOR_CHOICE && (particle.getMaxOccurs() > 1 || particle.getMaxOccursUnbounded());
+      final short compositor = group.getCompositor();
+      switch(compositor) {
+        case XSModelGroup.COMPOSITOR_CHOICE:
+        case XSModelGroup.COMPOSITOR_SEQUENCE:
+          return particle.getMaxOccurs() > 1 || particle.getMaxOccursUnbounded();
+        default:
+          return false;
+      }
+    }
+
+    private Schema createGroupSchema(String name, XSModelGroup groupTerm) {
+      Schema record = Schema.createRecord(name, null, null, false);
+      schemas.put(name, record);
+
+      Map<String,Schema.Field> fields = new HashMap<>();
+      createGroupFields(groupTerm, fields, false);
+      record.setFields(new ArrayList(fields.values()));
+
+      return Schema.createArray(record);
+    }
+
+    private List<XSParticle> getNestedGroupParticlesHavingMultipleOccurs(XSComplexTypeDefinition type) {
+        XSModelGroup groupTerm = (XSModelGroup) type.getParticle().getTerm();
+        XSObjectList particles = groupTerm.getParticles();
+        List<XSParticle> groupParticles = new ArrayList<>();
+        for (int i = 0; i < particles.getLength(); i++) {
+            XSParticle particle = (XSParticle) particles.item(i);
+            if(isGroupTypeWithMultipleOccurs(particle)) {
+              groupParticles.add(particle);
+            }
+        }
+        return groupParticles;
     }
 
     private Schema createRecordSchema(String name, XSComplexTypeDefinition type) {
@@ -227,8 +261,13 @@ public class SchemaBuilder {
                     fields.put(field.getProp(Source.SOURCE), field);
                     break;
                 case XSConstants.MODEL_GROUP:
-                    XSModelGroup subGroup = (XSModelGroup) term;
-                    createGroupFields(subGroup, fields, forceOptional || insideChoice);
+                  XSModelGroup subGroup = (XSModelGroup) term;
+                  if(particle.getMaxOccurs() <=1 && !particle.getMaxOccursUnbounded()) {
+                        createGroupFields(subGroup, fields, forceOptional || insideChoice);
+                    } else {
+                        String fieldName = nextTypeName();
+                        fields.put(fieldName, new Schema.Field(fieldName, createGroupSchema(nextTypeName(), subGroup), null, null));
+                    }
                     break;
                 case XSConstants.WILDCARD:
                     field = createField(fields.values(), term, null, forceOptional || optional, array);


### PR DESCRIPTION
When group particles have multiple occurrences, they need to be
considered as separate blocks in order to keep:
- ordering
- structure

Previously all the group particles occurrences were compressed into
a single set of fields together with their parent elements, dropping
all elements but the last one. The effect was quite devastating as
all the previous data except the last group was lost and moreover the
group structure logic was forgotten.

Example:
(sequence of s and choice of x or y)

```
<root>
  <s>s1</s>
  <x>x2</x>
  <y>3</y>
  <x>x4</x>
  <y>5</y>
</root>
```

Was (wrongly) translated into:

```
{
  “s” : “s1”,
  “x” : "x4",
  “y” : 5
}
```

After this change it is (correctly) translated into:

```
[ { “s” : “s1” },
  { “x” : “x2” },
  { “y” : 3 },
  { “x” : “x4” },
  { “y” : 5 } ]
```
